### PR TITLE
removed functionality to rank songs

### DIFF
--- a/prototype/generate_ranking.js
+++ b/prototype/generate_ranking.js
@@ -1,0 +1,37 @@
+//this script generates a degree of separation between the song title and keyword
+//it takes in two arguments: keyword and song title. As long as keyword argument is first,
+//no need to worry about song title having spaces
+
+let mergedArgs = '';
+for (let i = 3; i < process.argv.length; i++) {
+  mergedArgs += process.argv[i];
+  if (i < process.argv.length-1) {
+	  mergedArgs += '+'; //merge with plus sign, otherwise the call doesn't work
+  }
+}
+
+const filterString = (str) => {
+  // Convert any uppercase characters to lowercase
+  const lowercaseStr = str.toLowerCase();
+  
+  // Remove any non-lowercase characters or spaces
+  const filteredStr = lowercaseStr.replace(/[^a-z ]/g, '');
+
+  return filteredStr;
+};
+
+const keyword = process.argv[2].toLowerCase(); //keyword in lowercase
+
+const filtered_input = filterString(mergedArgs);
+
+if(filtered_input.includes(keyword)) {
+	console.log('keyword in song title');
+	return 0;	
+}
+
+
+
+
+//ideas:
+//if keyword appears immediately in filtered_input, return 0
+//if no data, return -1 and break

--- a/prototype/generate_ranking.js
+++ b/prototype/generate_ranking.js
@@ -2,6 +2,8 @@
 //it takes in two arguments: keyword and song title. As long as keyword argument is first,
 //no need to worry about song title having spaces
 
+const { exec } = require('child_process');
+
 let mergedArgs = '';
 for (let i = 3; i < process.argv.length; i++) {
   mergedArgs += process.argv[i];
@@ -29,7 +31,55 @@ if(filtered_input.includes(keyword)) {
 	return 0;	
 }
 
+let temp_trends_output = '';
 
+exec(`node get_related_terms_for_one_term.js ${keyword} ${filtered_input}`, (error, stdout, stderr) => {
+  if (error) {
+    console.error(`exec error: ${error}`);
+    return;
+  }
+  //console.log(`stdout: ${stdout}`);
+  //console.error(`stderr: ${stderr}`);
+  if (stdout.includes(keyword)) {
+	  console.log('degree of separation is 1');
+	  //return 1;
+  }
+  temp_trends_output = stdout;
+  //console.log(typeof stdout);
+  console.log(temp_trends_output); 
+  check_one_degree(temp_trends_output);
+  //console.log(typeof str);
+  //const arr = str.replace(/[{}]/g, '').split(',').map(str => str.trim());
+  //console.log(arr);
+});
+
+function check_one_degree(input_string) {
+	//inputs_array = input_string.split(',');
+	let inputs = "{" + input_string + "}";
+	inputs = inputs.replace(/\s+/g, "+");
+	
+	
+	exec(`node get_related_terms.js ${inputs}`, (error, stdout, stderr) => {
+	  if (error) {
+		console.error(`exec error: ${error}`);
+		return;
+	  }
+	  //console.log(`stdout: ${stdout}`);
+	  //console.error(`stderr: ${stderr}`);
+	  if (stdout.includes(keyword)) {
+		  console.log('degree of separation is 1');
+		  //return 1;
+	  }
+	  temp_trends_output = stdout;
+	  //console.log(typeof stdout);
+	  console.log(temp_trends_output); 
+	  //check_one_degree(temp_trends_output);
+	  //console.log(typeof str);
+	  //const arr = str.replace(/[{}]/g, '').split(',').map(str => str.trim());
+	  //console.log(arr);
+	});
+	
+};
 
 
 //ideas:

--- a/prototype/get_related_terms_for_one_term.js
+++ b/prototype/get_related_terms_for_one_term.js
@@ -97,7 +97,7 @@ async function getRelatedQueries(URL, searchQuery) {
   extractValues(json);
 
   // Return a string of all searchQuery values
-  const searchQueryString = searchQueryValues.join(', ');
+  const searchQueryString = searchQueryValues.join(',');
   console.log(searchQueryString);
   
   return(searchQueryString);

--- a/prototype/react_frontend/src/App.js
+++ b/prototype/react_frontend/src/App.js
@@ -169,7 +169,7 @@ function MyForm({ isLoggedIn }) {
 		
 		
 		const response = await axios.post(
-		  'http://localhost:5000/test_spotify_api',
+		  'http://localhost:5000/related_terms',
 		  { 
 			playlist: inputs.playlist, 
 			keyword: inputs.keyword 

--- a/prototype/server.js
+++ b/prototype/server.js
@@ -130,6 +130,30 @@ async function getPlaylistTracks(playlistId, playlistName) {
   return tracks;
 }
 
+async function generateRankings(playlistId, playlistName) {
+
+  const data = await spotifyApi.getPlaylistTracks(playlistId, {
+    offset: 1,
+    limit: 100,
+    fields: 'items'
+  })
+
+  // console.log('The playlist contains these tracks', data.body);
+  // console.log('The playlist contains these tracks: ', data.body.items[0].track);
+  // console.log("'" + playlistName + "'" + ' contains these tracks:');
+  let tracks = [];
+
+  for (let track_obj of data.body.items) {
+    const track = track_obj.track
+	//add exec call to file for generating ranking for one song title
+    tracks.push(track);
+    console.log(track.name + " : " + track.artists[0].name)
+  }
+  
+  console.log("---------------+++++++++++++++++++++++++")
+  return tracks;
+}
+
 //POST route instructions
 app.post('/test_google_trends', (req, res) => {
   const { playlist, keyword } = req.body;

--- a/prototype/server.js
+++ b/prototype/server.js
@@ -130,7 +130,7 @@ async function getPlaylistTracks(playlistId, playlistName) {
   return tracks;
 }
 
-async function generateRankings(playlistId, playlistName) {
+async function generateRelatedTermsfromPlaylist(playlistId, playlistName) {
 
   const data = await spotifyApi.getPlaylistTracks(playlistId, {
     offset: 1,
@@ -146,10 +146,10 @@ async function generateRankings(playlistId, playlistName) {
   for (let track_obj of data.body.items) {
     const track = track_obj.track
 	//add exec call to file for generating ranking for one song title
-    tracks.push(track);
-    console.log(track.name + " : " + track.artists[0].name)
+    tracks.push(track.name);
+    //console.log(track.name + " : " + track.artists[0].name)
   }
-  
+  console.log(tracks);
   console.log("---------------+++++++++++++++++++++++++")
   return tracks;
 }
@@ -341,6 +341,15 @@ app.post('/test_spotify_api', async (req, res) => {
   const parts = playlist.split('/');
   const playlistID = parts[parts.length - 1];
   getPlaylistTracks(playlistID, 'playlist');
+  res.status(200).send('worked');
+});
+
+app.post('/related_terms', async (req, res) => {
+  const { playlist, keyword } = req.body;
+  console.log(`New contact form submission: Playlist: ${playlist}, Keyword: ${keyword}`);
+  const parts = playlist.split('/');
+  const playlistID = parts[parts.length - 1];
+  generateRelatedTermsfromPlaylist(playlistID, 'playlist');
   res.status(200).send('worked');
 });
 


### PR DESCRIPTION
Originally, the app was supposed to rank songs based on proximity to a keyword. However, the current method of doing this, which is finding the "degree of separation" between the song title and keyword using a search tree made from "related keywords" queries to Google Trends, is unfortunately too CPU-heavy to be viable.

As a result, I'm shifting the focus towards just generating one "related keywords" query per song in the playlist. So rather than rank the songs, the app will print out related keywords for each song in the playlist.

This means something will have to be done about the "keyword" field. At the moment, I'm leaving it in until I'm sure that removing it won't break anything.